### PR TITLE
Advanced error decoding

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		0F22960A24D028DA00EF4F8F /* StreamUploadEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F22960924D028DA00EF4F8F /* StreamUploadEndpointTests.swift */; };
 		59230CD861919924787FBD90 /* Pods_ExampleAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 986550D9D8D646CD39BFD44A /* Pods_ExampleAPI.framework */; };
 		7F25F8B767BEF06DB8B3B440 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D9C14D1741721987B950ADC /* Pods_Example.framework */; };
+		C6AE285E25B1FCE90095EA8C /* UploadEndpoint+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6AE285D25B1FCE90095EA8C /* UploadEndpoint+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -117,6 +118,7 @@
 		8D9C14D1741721987B950ADC /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		986550D9D8D646CD39BFD44A /* Pods_ExampleAPI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleAPI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A7444102FDF3BF64D170F337 /* Pods-ExampleAPI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleAPI.release.xcconfig"; path = "Target Support Files/Pods-ExampleAPI/Pods-ExampleAPI.release.xcconfig"; sourceTree = "<group>"; };
+		C6AE285D25B1FCE90095EA8C /* UploadEndpoint+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UploadEndpoint+Extension.swift"; sourceTree = "<group>"; };
 		EF67CE46DB5494E09A3CB131 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
 		F31AB0223F4479EEE604472A /* Pods-ExampleAPI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleAPI.debug.xcconfig"; path = "Target Support Files/Pods-ExampleAPI/Pods-ExampleAPI.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -273,6 +275,7 @@
 			children = (
 				0246DD2F22B8D808007AD11C /* JsonEndpoint.swift */,
 				0246DD2D22B8D807007AD11C /* EmptyEndpoint.swift */,
+				C6AE285D25B1FCE90095EA8C /* UploadEndpoint+Extension.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -602,6 +605,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0F2295F524D022B300EF4F8F /* EmptyEndpoint.swift in Sources */,
+				C6AE285E25B1FCE90095EA8C /* UploadEndpoint+Extension.swift in Sources */,
 				0F2295FF24D0230100EF4F8F /* HTTPError.swift in Sources */,
 				0F2295FB24D022E400EF4F8F /* Form.swift in Sources */,
 				0F22960024D0230100EF4F8F /* ResponseValidator.swift in Sources */,

--- a/Example/ExampleAPI/Endpoint/Base/EmptyEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/Base/EmptyEndpoint.swift
@@ -12,13 +12,15 @@ protocol EmptyEndpoint: Endpoint, URLRequestBuildable where Content == Void {}
 
 extension EmptyEndpoint {
 
-    public typealias ErrorType = Error
+    public typealias Failure = Error
     
-    public func content(from response: URLResponse?, with body: Data) throws {
-        try ResponseValidator.validate(response, with: body)
-    }
-    
-    public func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> ErrorType {
-        return error
+    func decode(fromResponse response: URLResponse?, withResult result: Result<Data, Error>) -> Result<Content, Failure> {
+        return result.flatMap { body -> Result<Content, Error> in
+            do {
+                return .success(try ResponseValidator.validate(response, with: body))
+            } catch {
+                return .failure(error)
+            }
+        }
     }
 }

--- a/Example/ExampleAPI/Endpoint/Base/EmptyEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/Base/EmptyEndpoint.swift
@@ -12,7 +12,13 @@ protocol EmptyEndpoint: Endpoint, URLRequestBuildable where Content == Void {}
 
 extension EmptyEndpoint {
 
+    public typealias ErrorType = Error
+    
     public func content(from response: URLResponse?, with body: Data) throws {
         try ResponseValidator.validate(response, with: body)
+    }
+    
+    func error(from response: URLResponse?, with body: Data?, and error: Error) -> ErrorType {
+        return error
     }
 }

--- a/Example/ExampleAPI/Endpoint/Base/EmptyEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/Base/EmptyEndpoint.swift
@@ -18,7 +18,7 @@ extension EmptyEndpoint {
         try ResponseValidator.validate(response, with: body)
     }
     
-    func error(from response: URLResponse?, with body: Data?, and error: Error) -> ErrorType {
+    public func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> ErrorType {
         return error
     }
 }

--- a/Example/ExampleAPI/Endpoint/Base/JsonEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/Base/JsonEndpoint.swift
@@ -25,7 +25,7 @@ extension JsonEndpoint {
         return resource.data
     }
     
-    public func error(from response: URLResponse?, with body: Data?, and error: Error) -> ErrorType {
+    public func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> ErrorType {
         return error
     }
 }

--- a/Example/ExampleAPI/Endpoint/Base/JsonEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/Base/JsonEndpoint.swift
@@ -14,6 +14,8 @@ protocol JsonEndpoint: Endpoint, URLRequestBuildable where Content: Decodable {}
 
 extension JsonEndpoint {
 
+    public typealias ErrorType = Error
+    
     /// Request body encoder.
     internal var encoder: JSONEncoder { return JSONEncoder.default }
 
@@ -21,6 +23,10 @@ extension JsonEndpoint {
         try ResponseValidator.validate(response, with: body)
         let resource = try JSONDecoder.default.decode(ResponseData<Content>.self, from: body)
         return resource.data
+    }
+    
+    public func error(from response: URLResponse?, with body: Data?, and error: Error) -> ErrorType {
+        return error
     }
 }
 

--- a/Example/ExampleAPI/Endpoint/Base/UploadEndpoint+Extension.swift
+++ b/Example/ExampleAPI/Endpoint/Base/UploadEndpoint+Extension.swift
@@ -12,7 +12,7 @@ extension UploadEndpoint {
 
     public typealias ErrorType = Error
     
-    public func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+    public func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
         return error
     }
 }

--- a/Example/ExampleAPI/Endpoint/Base/UploadEndpoint+Extension.swift
+++ b/Example/ExampleAPI/Endpoint/Base/UploadEndpoint+Extension.swift
@@ -10,7 +10,7 @@ import Apexy
 
 extension UploadEndpoint {
 
-    public typealias ErrorType = Error
+    public typealias Failure = Error
     
     public func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
         return error

--- a/Example/ExampleAPI/Endpoint/Base/UploadEndpoint+Extension.swift
+++ b/Example/ExampleAPI/Endpoint/Base/UploadEndpoint+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  UploadEndpoint.swift
+//  ExampleAPI
+//
+//  Created by Aleksei Tiurnin on 15.01.2021.
+//  Copyright © 2021 RedMadRobot. All rights reserved.
+//
+
+import Apexy
+
+extension UploadEndpoint {
+
+    public typealias ErrorType = Error
+    
+    public func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+        return error
+    }
+}

--- a/Example/ExampleAPI/Endpoint/BookListEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/BookListEndpoint.swift
@@ -15,8 +15,7 @@ public struct BookListEndpoint: JsonEndpoint {
     
     public init() {}
     
-    public func makeRequest() throws -> URLRequest {
-        return get(URL(string: "books")!)
+    public func makeRequest() -> Result<URLRequest, Error> {
+        return .success(get(URL(string: "books")!))
     }
-
 }

--- a/Example/ExampleAPI/Endpoint/BookListEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/BookListEndpoint.swift
@@ -12,6 +12,7 @@ public struct BookListEndpoint: JsonEndpoint {
     
     public typealias Content = [Book]
 
+    
     public init() {}
     
     public func makeRequest() throws -> URLRequest {

--- a/Example/ExampleAPI/Endpoint/BookListEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/BookListEndpoint.swift
@@ -11,7 +11,6 @@ import Apexy
 public struct BookListEndpoint: JsonEndpoint {
     
     public typealias Content = [Book]
-
     
     public init() {}
     

--- a/Example/ExampleAPI/Endpoint/FileUploadEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/FileUploadEndpoint.swift
@@ -12,6 +12,7 @@ import Apexy
 public struct FileUploadEndpoint: UploadEndpoint {
     
     public typealias Content = Void
+    public typealias ErrorType = Error
     
     private let fileURL: URL
     

--- a/Example/ExampleAPI/Endpoint/StreamUploadEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/StreamUploadEndpoint.swift
@@ -12,7 +12,7 @@ import Apexy
 public struct StreamUploadEndpoint: UploadEndpoint {
     
     public typealias Content = Void
-    public typealias ErrorType = Error
+    public typealias Failure = Error
     
     private let stream: InputStream
     private let size: Int
@@ -22,17 +22,23 @@ public struct StreamUploadEndpoint: UploadEndpoint {
         self.size = size
     }
     
-    public func content(from response: URLResponse?, with body: Data) throws {
-        try ResponseValidator.validate(response, with: body)
-    }
-    
-    public func makeRequest() throws -> (URLRequest, UploadEndpointBody) {
+    public func makeRequest() -> Result<(URLRequest, UploadEndpointBody), Error> {
         var request = URLRequest(url: URL(string: "upload")!)
         request.httpMethod = "POST"
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
         
         // To track upload progress, it is important to set the Content-Length value.
         request.setValue("\(size)", forHTTPHeaderField: "Content-Length")
-        return (request, .stream(stream))
+        return .success((request, .stream(stream)))
+    }
+    
+    public func decode(fromResponse response: URLResponse?, withResult result: Result<Data, Error>) -> Result<Void, Error> {
+        return result.flatMap { body -> Result<Void, Error> in
+            do {
+                return .success(try ResponseValidator.validate(response, with: body))
+            } catch {
+                return .failure(error)
+            }
+        }
     }
 }

--- a/Example/ExampleAPI/Endpoint/StreamUploadEndpoint.swift
+++ b/Example/ExampleAPI/Endpoint/StreamUploadEndpoint.swift
@@ -12,6 +12,7 @@ import Apexy
 public struct StreamUploadEndpoint: UploadEndpoint {
     
     public typealias Content = Void
+    public typealias ErrorType = Error
     
     private let stream: InputStream
     private let size: Int

--- a/Example/ExampleAPITests/Endpoint/BookListEndpointTests.swift
+++ b/Example/ExampleAPITests/Endpoint/BookListEndpointTests.swift
@@ -13,10 +13,12 @@ final class BookListEndpointTests: XCTestCase {
 
     func testMakeRequest() throws {
         let endpoint = BookListEndpoint()
-        let urlRequest = try endpoint.makeRequest()
+        let urlRequest = endpoint.makeRequest()
         
-        assertGET(urlRequest)
-        assertURL(urlRequest, "books")
+        let request = try! urlRequest.get()
+        
+        assertGET(request)
+        assertURL(request, "books")
     }
 
 }

--- a/Example/ExampleAPITests/Endpoint/FileUploadEndpointTests.swift
+++ b/Example/ExampleAPITests/Endpoint/FileUploadEndpointTests.swift
@@ -15,7 +15,7 @@ final class FileUploadEndpointTests: XCTestCase {
         let fileURL = URL(string: "path/to/file")!
         let endpoint = FileUploadEndpoint(fileURL: fileURL)
         
-        let (request, body) = try endpoint.makeRequest()
+        let (request, body) = try! endpoint.makeRequest().get()
         
         assertPOST(request)
         assertURL(request, "upload")

--- a/Example/ExampleAPITests/Endpoint/StreamUploadEndpointTests.swift
+++ b/Example/ExampleAPITests/Endpoint/StreamUploadEndpointTests.swift
@@ -16,7 +16,7 @@ final class StreamUploadEndpointTests: XCTestCase {
         let fileSize = 1024
         let endpoint = StreamUploadEndpoint(stream: fileStream, size: fileSize)
         
-        let (request, body) = try endpoint.makeRequest()
+        let (request, body) = try! endpoint.makeRequest().get()
         
         assertPOST(request)
         assertURL(request, "upload")

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - Alamofire (5.2.2)
-  - Apexy (1.1.0):
-    - Apexy/Alamofire (= 1.1.0)
-  - Apexy/Alamofire (1.1.0):
+  - Apexy (1.2.0):
+    - Apexy/Alamofire (= 1.2.0)
+  - Apexy/Alamofire (1.2.0):
     - Alamofire (~> 5.0)
     - Apexy/Core
-  - Apexy/Core (1.1.0)
+  - Apexy/Core (1.2.0)
 
 DEPENDENCIES:
   - Apexy (from `../`)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: 814429acc853c6c54ff123fc3d2ef66803823ce0
-  Apexy: e2068c473a18be292450f60bbce6089a75270e1b
+  Apexy: f669411a11a83a4053c8a653b6590cb78fb46e1d
 
 PODFILE CHECKSUM: f86a90e7590ccb3aa7caeceaf315abe256650c66
 

--- a/Sources/Apexy/Client+Combine.swift
+++ b/Sources/Apexy/Client+Combine.swift
@@ -8,10 +8,10 @@ public extension Client {
     @available(macOS 10.15, *)
     @available(tvOS 13.0, *)
     @available(watchOS 6.0, *)
-    func request<T>(_ endpoint: T) -> AnyPublisher<T.Content, T.ErrorType> where T: Endpoint {
-        let subject = PassthroughSubject<T.Content, T.ErrorType>()
+    func request<T>(_ endpoint: T) -> AnyPublisher<T.Content, T.Failure> where T: Endpoint {
+        let subject = PassthroughSubject<T.Content, T.Failure>()
         
-        let progress = self.request(endpoint) { (result: Result<T.Content, T.ErrorType>) in
+        let progress = self.request(endpoint) { (result: Result<T.Content, T.Failure>) in
             switch result {
             case .success(let content):
                 subject.send(content)

--- a/Sources/Apexy/Client+Combine.swift
+++ b/Sources/Apexy/Client+Combine.swift
@@ -8,10 +8,10 @@ public extension Client {
     @available(macOS 10.15, *)
     @available(tvOS 13.0, *)
     @available(watchOS 6.0, *)
-    func request<T>(_ endpoint: T) -> AnyPublisher<T.Content, Error> where T: Endpoint {
-        let subject = PassthroughSubject<T.Content, Error>()
+    func request<T>(_ endpoint: T) -> AnyPublisher<T.Content, T.ErrorType> where T: Endpoint {
+        let subject = PassthroughSubject<T.Content, T.ErrorType>()
         
-        let progress = self.request(endpoint) { (result: Result<T.Content, Error>) in
+        let progress = self.request(endpoint) { (result: Result<T.Content, T.ErrorType>) in
             switch result {
             case .success(let content):
                 subject.send(content)

--- a/Sources/Apexy/Client.swift
+++ b/Sources/Apexy/Client.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-public typealias APIResult<Value> = Swift.Result<Value, Error>
-
 public protocol Client: AnyObject {
     
     /// Send request to specified endpoint.
@@ -12,7 +10,7 @@ public protocol Client: AnyObject {
     /// - Returns: The progress of fetching the response data from the server for the request.
     func request<T>(
         _ endpoint: T,
-        completionHandler: @escaping (APIResult<T.Content>) -> Void
+        completionHandler: @escaping (Result<T.Content, T.ErrorType>) -> Void
     ) -> Progress where T: Endpoint
     
     /// Upload data to specified endpoint.
@@ -23,6 +21,6 @@ public protocol Client: AnyObject {
     /// - Returns: The progress of uploading data to the server.
     func upload<T>(
         _ endpoint: T,
-        completionHandler: @escaping (APIResult<T.Content>) -> Void
+        completionHandler: @escaping (Result<T.Content, T.ErrorType>) -> Void
     ) -> Progress where T: UploadEndpoint
 }

--- a/Sources/Apexy/Client.swift
+++ b/Sources/Apexy/Client.swift
@@ -10,7 +10,7 @@ public protocol Client: AnyObject {
     /// - Returns: The progress of fetching the response data from the server for the request.
     func request<T>(
         _ endpoint: T,
-        completionHandler: @escaping (Result<T.Content, T.ErrorType>) -> Void
+        completionHandler: @escaping (Result<T.Content, T.Failure>) -> Void
     ) -> Progress where T: Endpoint
     
     /// Upload data to specified endpoint.
@@ -21,6 +21,6 @@ public protocol Client: AnyObject {
     /// - Returns: The progress of uploading data to the server.
     func upload<T>(
         _ endpoint: T,
-        completionHandler: @escaping (Result<T.Content, T.ErrorType>) -> Void
+        completionHandler: @escaping (Result<T.Content, T.Failure>) -> Void
     ) -> Progress where T: UploadEndpoint
 }

--- a/Sources/Apexy/Endpoint.swift
+++ b/Sources/Apexy/Endpoint.swift
@@ -14,6 +14,9 @@ public protocol Endpoint {
     ///
     /// - Author: Nino
     associatedtype Content
+    
+    /// Error type
+    associatedtype ErrorType: Error
 
     /// Create a new `URLRequest`.
     ///
@@ -29,6 +32,16 @@ public protocol Endpoint {
     /// - Returns: A new endpoint content.
     /// - Throws: Any error creating content.
     func content(from response: URLResponse?, with body: Data) throws -> Content
+    
+    /// Obtain error from response with body.
+    ///
+    /// - Parameters:
+    ///   - response: The metadata associated with the response.
+    ///   - body: The response body.
+    ///   - error: The response error.
+    /// - Returns: A new endpoint error.
+    /// - Throws: Any error creating error.
+    func error(from response: URLResponse?, with body: Data?, and error: Error) -> ErrorType
 
     /// Validate response.
     ///

--- a/Sources/Apexy/Endpoint.swift
+++ b/Sources/Apexy/Endpoint.swift
@@ -16,43 +16,20 @@ public protocol Endpoint {
     associatedtype Content
     
     /// Error type
-    associatedtype ErrorType: Error
+    associatedtype Failure: Error
 
     /// Create a new `URLRequest`.
     ///
     /// - Returns: Resource request.
-    /// - Throws: Any error creating request.
-    func makeRequest() throws -> URLRequest
+    func makeRequest() -> Result<URLRequest, Failure>
 
-    /// Obtain new content from response with body.
+    /// Obtain content from response with result
     ///
     /// - Parameters:
     ///   - response: The metadata associated with the response.
-    ///   - body: The response body.
+    ///   - result: Result which contain Data or Error
     /// - Returns: A new endpoint content.
-    /// - Throws: Any error creating content.
-    func content(from response: URLResponse?, with body: Data) throws -> Content
-    
-    /// Obtain error from response with body.
-    ///
-    /// - Parameters:
-    ///   - response: The metadata associated with the response.
-    ///   - body: The response body.
-    ///   - error: The response error.
-    /// - Returns: A new endpoint error.
-    /// - Throws: Any error creating error.
-    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> ErrorType
-
-    /// Validate response.
-    ///
-    /// - Parameters:
-    ///   - request: The metadata associated with the request.
-    ///   - response: The metadata associated with the response.
-    ///   - data: The response body data.
-    /// - Throws: Any response validation error.
-    func validate(_ request: URLRequest?, response: HTTPURLResponse, data: Data?) throws
-}
-
-public extension Endpoint {
-    func validate(_ request: URLRequest?, response: HTTPURLResponse, data: Data?) { }
+    func decode(
+        fromResponse response: URLResponse?,
+        withResult result: Result<Data, Error>) -> Result<Content, Failure>
 }

--- a/Sources/Apexy/Endpoint.swift
+++ b/Sources/Apexy/Endpoint.swift
@@ -41,7 +41,7 @@ public protocol Endpoint {
     ///   - error: The response error.
     /// - Returns: A new endpoint error.
     /// - Throws: Any error creating error.
-    func error(from response: URLResponse?, with body: Data?, and error: Error) -> ErrorType
+    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> ErrorType
 
     /// Validate response.
     ///

--- a/Sources/Apexy/UploadEndpoint.swift
+++ b/Sources/Apexy/UploadEndpoint.swift
@@ -46,5 +46,5 @@ public protocol UploadEndpoint {
     ///   - error: The response error.
     /// - Returns: A new endpoint error.
     /// - Throws: Any error creating error.
-    func error(from response: URLResponse?, with body: Data?, and error: Error) -> ErrorType
+    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> ErrorType
 }

--- a/Sources/Apexy/UploadEndpoint.swift
+++ b/Sources/Apexy/UploadEndpoint.swift
@@ -18,6 +18,10 @@ public protocol UploadEndpoint {
     
     /// Response type.
     associatedtype Content
+    
+    
+    /// Error type
+    associatedtype ErrorType: Error
 
     /// Create a new `URLRequest` and uploadable payload.
     ///
@@ -34,4 +38,13 @@ public protocol UploadEndpoint {
     /// - Throws: Any error creating content.
     func content(from response: URLResponse?, with body: Data) throws -> Content
     
+    /// Obtain error from response with body.
+    ///
+    /// - Parameters:
+    ///   - response: The metadata associated with the response.
+    ///   - body: The response body.
+    ///   - error: The response error.
+    /// - Returns: A new endpoint error.
+    /// - Throws: Any error creating error.
+    func error(from response: URLResponse?, with body: Data?, and error: Error) -> ErrorType
 }

--- a/Sources/Apexy/UploadEndpoint.swift
+++ b/Sources/Apexy/UploadEndpoint.swift
@@ -21,30 +21,20 @@ public protocol UploadEndpoint {
     
     
     /// Error type
-    associatedtype ErrorType: Error
+    associatedtype Failure: Error
 
-    /// Create a new `URLRequest` and uploadable payload.
+    /// Create a new `URLRequest`.
     ///
-    /// - Returns: Resource request and uploadable data
-    /// - Throws: Any error creating request.
-    func makeRequest() throws -> (URLRequest, UploadEndpointBody)
+    /// - Returns: Resource request.
+    func makeRequest() -> Result<(URLRequest, UploadEndpointBody), Failure>
 
-    /// Obtain new content from response with body.
+    /// Obtain content from response with result
     ///
     /// - Parameters:
     ///   - response: The metadata associated with the response.
-    ///   - body: The response body.
+    ///   - result: Result which contain Data or Error
     /// - Returns: A new endpoint content.
-    /// - Throws: Any error creating content.
-    func content(from response: URLResponse?, with body: Data) throws -> Content
-    
-    /// Obtain error from response with body.
-    ///
-    /// - Parameters:
-    ///   - response: The metadata associated with the response.
-    ///   - body: The response body.
-    ///   - error: The response error.
-    /// - Returns: A new endpoint error.
-    /// - Throws: Any error creating error.
-    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> ErrorType
+    func decode(
+        fromResponse response: URLResponse?,
+        withResult result: Result<Data, Error>) -> Result<Content, Failure>
 }

--- a/Sources/Apexy/UploadEndpoint.swift
+++ b/Sources/Apexy/UploadEndpoint.swift
@@ -19,7 +19,6 @@ public protocol UploadEndpoint {
     /// Response type.
     associatedtype Content
     
-    
     /// Error type
     associatedtype Failure: Error
 

--- a/Sources/ApexyAlamofire/AlamofireClient.swift
+++ b/Sources/ApexyAlamofire/AlamofireClient.swift
@@ -108,14 +108,14 @@ open class AlamofireClient: Client {
 
                     let httpResponse = response.response
                     let result = response.result
-                        .mapError{ error -> T.ErrorType in
-                            return endpoint.error(from: httpResponse, with: nil, and: error)
+                        .mapError { error -> T.ErrorType in
+                            return endpoint.error(fromResponse: httpResponse, withBody: nil, withError: error)
                         }
                         .flatMap { data -> Result<T.Content, T.ErrorType> in
                             do {
                                 return try .success(endpoint.content(from: httpResponse, with: data))
                             } catch {
-                                return .failure(endpoint.error(from: httpResponse, with: data, and: error))
+                                return .failure(endpoint.error(fromResponse: httpResponse, withBody: data, withError: error))
                             }
                         }
 
@@ -144,7 +144,7 @@ open class AlamofireClient: Client {
         do {
             (urlRequest, body) = try endpoint.makeRequest()
         } catch {
-            completionHandler(.failure(endpoint.error(from: nil, with: nil, and: error)))
+            completionHandler(.failure(endpoint.error(fromResponse: nil, withBody: nil, withError: error)))
             return Progress()
         }
         
@@ -164,14 +164,14 @@ open class AlamofireClient: Client {
 
                 let httpResponse = response.response
                 let result = response.result
-                    .mapError{ error -> T.ErrorType in
-                        return endpoint.error(from: httpResponse, with: nil, and: error)
+                    .mapError { error -> T.ErrorType in
+                        return endpoint.error(fromResponse: httpResponse, withBody: nil, withError: error)
                     }
                     .flatMap { data -> Result<T.Content, T.ErrorType> in
                         do {
                             return try .success(endpoint.content(from: httpResponse, with: data))
                         } catch {
-                            return .failure(endpoint.error(from: httpResponse, with: data, and: error))
+                            return .failure(endpoint.error(fromResponse: httpResponse, withBody: data, withError: error))
                         }
                     }
 

--- a/Sources/ApexyAlamofire/AlamofireClient.swift
+++ b/Sources/ApexyAlamofire/AlamofireClient.swift
@@ -101,7 +101,9 @@ open class AlamofireClient: Client {
         let urlRequestResult = endpoint.makeRequest()
         guard case let .success(urlRequest) = urlRequestResult else {
             if case let .failure(error) = urlRequestResult {
-                completionHandler(.failure(error))
+                completionQueue.async {
+                    completionHandler(.failure(error))
+                }
             }
             return Progress()
         }

--- a/Sources/ApexyRxSwift/Client+RxSwift.swift
+++ b/Sources/ApexyRxSwift/Client+RxSwift.swift
@@ -5,7 +5,7 @@ public extension Client {
     
     func request<T>(_ endpoint: T) -> Single<T.Content> where T: Endpoint {
         Single.create { single in
-            let progress = self.request(endpoint) { (result: Result<T.Content, T.ErrorType>) in
+            let progress = self.request(endpoint) { (result: Result<T.Content, T.Failure>) in
                 switch result {
                 case .success(let content):
                     single(.success(content))

--- a/Sources/ApexyRxSwift/Client+RxSwift.swift
+++ b/Sources/ApexyRxSwift/Client+RxSwift.swift
@@ -5,7 +5,7 @@ public extension Client {
     
     func request<T>(_ endpoint: T) -> Single<T.Content> where T: Endpoint {
         Single.create { single in
-            let progress = self.request(endpoint) { (result: Result<T.Content, Error>) in
+            let progress = self.request(endpoint) { (result: Result<T.Content, T.ErrorType>) in
                 switch result {
                 case .success(let content):
                     single(.success(content))

--- a/Sources/ApexyURLSession/URLSessionClient.swift
+++ b/Sources/ApexyURLSession/URLSessionClient.swift
@@ -37,19 +37,20 @@ open class URLSessionClient: Client {
     
     open func request<T>(
         _ endpoint: T,
-        completionHandler: @escaping (APIResult<T.Content>) -> Void) -> Progress where T : Endpoint {
+        completionHandler: @escaping (Result<T.Content, T.ErrorType>) -> Void) -> Progress where T : Endpoint {
         
         var request: URLRequest
         do {
             request = try endpoint.makeRequest()
             request = try requestAdapter.adapt(request)
         } catch {
-            completionHandler(.failure(error))
+            completionHandler(.failure(endpoint.error(from: nil, with: nil, and: error)))
             return Progress()
         }
         
         let task = session.dataTask(with: request) { (data, response, error) in
-            let result = APIResult<T.Content>(catching: { () throws -> T.Content in
+
+            let result = Result<T.Content, Error>(catching: { () throws -> T.Content in
                 if let httpResponse = response as? HTTPURLResponse {
                     try endpoint.validate(request, response: httpResponse, data: data)
                 }
@@ -58,7 +59,9 @@ open class URLSessionClient: Client {
                     throw error
                 }
                 return try endpoint.content(from: response, with: data)
-            })
+            }).mapError { error -> T.ErrorType in
+                return endpoint.error(from: response as? HTTPURLResponse, with: data, and: error)
+            }
             self.completionQueue.async {
                 self.responseObserver?(request, response as? HTTPURLResponse, data, error)
                 completionHandler(result)
@@ -69,24 +72,26 @@ open class URLSessionClient: Client {
         return task.progress
     }
     
-    open func upload<T>(_ endpoint: T, completionHandler: @escaping (APIResult<T.Content>) -> Void) -> Progress where T : UploadEndpoint {
+    open func upload<T>(_ endpoint: T, completionHandler: @escaping (Result<T.Content, T.ErrorType>) -> Void) -> Progress where T : UploadEndpoint {
         var request: (URLRequest, UploadEndpointBody)
         do {
             request = try endpoint.makeRequest()
             request.0 = try requestAdapter.adapt(request.0)
         } catch {
-            completionHandler(.failure(error))
+            completionHandler(.failure(endpoint.error(from: nil, with: nil, and: error)))
             return Progress()
         }
         
         let handler: (Data?, URLResponse?, Error?) -> Void = { (data, response, error) in
-            let result = APIResult<T.Content>(catching: { () throws -> T.Content in
+            let result = Result<T.Content, Error>(catching: { () throws -> T.Content in
                 let data = data ?? Data()
                 if let error = error {
                     throw error
                 }
                 return try endpoint.content(from: response, with: data)
-            })
+            }).mapError { error -> T.ErrorType in
+                return endpoint.error(from: response as? HTTPURLResponse, with: data, and: error)
+            }
             self.completionQueue.async {
                 self.responseObserver?(request.0, response as? HTTPURLResponse, data, error)
                 completionHandler(result)
@@ -100,7 +105,10 @@ open class URLSessionClient: Client {
         case (let request, .file(let url)):
             task = session.uploadTask(with: request, fromFile: url, completionHandler: handler)
         case (_, .stream):
-            completionHandler(.failure(URLSessionClientError.uploadStreamUnimplemented))
+            completionHandler(.failure(endpoint.error(
+                                        from: nil,
+                                        with: nil,
+                                        and: URLSessionClientError.uploadStreamUnimplemented)))
             return Progress()
         }
         task.resume()

--- a/Sources/ApexyURLSession/URLSessionClient.swift
+++ b/Sources/ApexyURLSession/URLSessionClient.swift
@@ -44,7 +44,7 @@ open class URLSessionClient: Client {
             request = try endpoint.makeRequest()
             request = try requestAdapter.adapt(request)
         } catch {
-            completionHandler(.failure(endpoint.error(from: nil, with: nil, and: error)))
+            completionHandler(.failure(endpoint.error(fromResponse: nil, withBody: nil, withError: error)))
             return Progress()
         }
         
@@ -60,7 +60,7 @@ open class URLSessionClient: Client {
                 }
                 return try endpoint.content(from: response, with: data)
             }).mapError { error -> T.ErrorType in
-                return endpoint.error(from: response as? HTTPURLResponse, with: data, and: error)
+                return endpoint.error(fromResponse: response as? HTTPURLResponse, withBody: data, withError: error)
             }
             self.completionQueue.async {
                 self.responseObserver?(request, response as? HTTPURLResponse, data, error)
@@ -78,7 +78,7 @@ open class URLSessionClient: Client {
             request = try endpoint.makeRequest()
             request.0 = try requestAdapter.adapt(request.0)
         } catch {
-            completionHandler(.failure(endpoint.error(from: nil, with: nil, and: error)))
+            completionHandler(.failure(endpoint.error(fromResponse: nil, withBody: nil, withError: error)))
             return Progress()
         }
         
@@ -90,7 +90,7 @@ open class URLSessionClient: Client {
                 }
                 return try endpoint.content(from: response, with: data)
             }).mapError { error -> T.ErrorType in
-                return endpoint.error(from: response as? HTTPURLResponse, with: data, and: error)
+                return endpoint.error(fromResponse: response as? HTTPURLResponse, withBody: data, withError: error)
             }
             self.completionQueue.async {
                 self.responseObserver?(request.0, response as? HTTPURLResponse, data, error)
@@ -106,9 +106,9 @@ open class URLSessionClient: Client {
             task = session.uploadTask(with: request, fromFile: url, completionHandler: handler)
         case (_, .stream):
             completionHandler(.failure(endpoint.error(
-                                        from: nil,
-                                        with: nil,
-                                        and: URLSessionClientError.uploadStreamUnimplemented)))
+                                        fromResponse: nil,
+                                        withBody: nil,
+                                        withError: URLSessionClientError.uploadStreamUnimplemented)))
             return Progress()
         }
         task.resume()

--- a/Sources/ApexyURLSession/URLSessionClient.swift
+++ b/Sources/ApexyURLSession/URLSessionClient.swift
@@ -42,7 +42,9 @@ open class URLSessionClient: Client {
         let urlRequestResult = endpoint.makeRequest()
         guard case let .success(urlRequest) = urlRequestResult else {
             if case let .failure(error) = urlRequestResult {
-                completionHandler(.failure(error))
+                self.completionQueue.async {
+                    completionHandler(.failure(error))
+                }
             }
             return Progress()
         }
@@ -50,7 +52,9 @@ open class URLSessionClient: Client {
         do {
             request = try requestAdapter.adapt(urlRequest)
         } catch {
-            completionHandler(endpoint.decode(fromResponse: nil, withResult: .failure(error)))
+            self.completionQueue.async {
+                completionHandler(endpoint.decode(fromResponse: nil, withResult: .failure(error)))
+            }
             return Progress()
         }
         

--- a/Tests/ApexyAlamofireTests/AlamofireClientTests.swift
+++ b/Tests/ApexyAlamofireTests/AlamofireClientTests.swift
@@ -105,7 +105,7 @@ private struct EmptyEndpoint: Endpoint {
         return body
     }
     
-    func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
         return error
     }
 }
@@ -133,7 +133,7 @@ private struct SimpleUploadEndpoint: UploadEndpoint {
         body
     }
     
-    func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
         return error
     }
 }

--- a/Tests/ApexyAlamofireTests/AlamofireClientTests.swift
+++ b/Tests/ApexyAlamofireTests/AlamofireClientTests.swift
@@ -95,25 +95,21 @@ private final class MockURLProtocol: URLProtocol {
 private struct EmptyEndpoint: Endpoint {
     
     typealias Content = Data
-    typealias ErrorType = Error
+    typealias Failure = Error
     
-    func makeRequest() throws -> URLRequest {
-        URLRequest(url: URL(string: "empty")!)
+    func makeRequest() -> Result<URLRequest, Error> {
+        return .success(URLRequest(url: URL(string: "empty")!))
     }
     
-    func content(from response: URLResponse?, with body: Data) throws -> Data {
-        return body
-    }
-    
-    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
-        return error
+    func decode(fromResponse response: URLResponse?, withResult result: Result<Data, Error>) -> Result<Data, Error> {
+        return result
     }
 }
 
 private struct SimpleUploadEndpoint: UploadEndpoint {
-   
+
     typealias Content = Data
-    typealias ErrorType = Error
+    typealias Failure = Error
     
     private let data: Data
     
@@ -121,20 +117,16 @@ private struct SimpleUploadEndpoint: UploadEndpoint {
         self.data = data
     }
     
-    func makeRequest() throws -> (URLRequest, UploadEndpointBody) {
+    func makeRequest() -> Result<(URLRequest, UploadEndpointBody), Error> {
         var req = URLRequest(url: URL(string: "upload")!)
         req.httpMethod = "POST"
         
         let body = UploadEndpointBody.data(data)
-        return (req, body)
+        return .success((req, body))
     }
     
-    func content(from response: URLResponse?, with body: Data) throws -> Data {
-        body
-    }
-    
-    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
-        return error
+    func decode(fromResponse response: URLResponse?, withResult result: Result<Data, Error>) -> Result<Data, Error> {
+        return result
     }
 }
 

--- a/Tests/ApexyAlamofireTests/AlamofireClientTests.swift
+++ b/Tests/ApexyAlamofireTests/AlamofireClientTests.swift
@@ -95,6 +95,7 @@ private final class MockURLProtocol: URLProtocol {
 private struct EmptyEndpoint: Endpoint {
     
     typealias Content = Data
+    typealias ErrorType = Error
     
     func makeRequest() throws -> URLRequest {
         URLRequest(url: URL(string: "empty")!)
@@ -103,11 +104,16 @@ private struct EmptyEndpoint: Endpoint {
     func content(from response: URLResponse?, with body: Data) throws -> Data {
         return body
     }
+    
+    func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+        return error
+    }
 }
 
 private struct SimpleUploadEndpoint: UploadEndpoint {
    
     typealias Content = Data
+    typealias ErrorType = Error
     
     private let data: Data
     
@@ -125,6 +131,10 @@ private struct SimpleUploadEndpoint: UploadEndpoint {
     
     func content(from response: URLResponse?, with body: Data) throws -> Data {
         body
+    }
+    
+    func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+        return error
     }
 }
 

--- a/Tests/ApexyURLSessionTests/URLSessionClientTests.swift
+++ b/Tests/ApexyURLSessionTests/URLSessionClientTests.swift
@@ -167,7 +167,7 @@ private struct EmptyEndpoint: Endpoint {
         }
     }
     
-    func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
         return error
     }
 }
@@ -195,7 +195,7 @@ private struct SimpleUploadEndpoint: UploadEndpoint {
         body
     }
     
-    func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
         return error
     }
 }

--- a/Tests/ApexyURLSessionTests/URLSessionClientTests.swift
+++ b/Tests/ApexyURLSessionTests/URLSessionClientTests.swift
@@ -149,54 +149,43 @@ private final class MockURLProtocol: URLProtocol {
 private struct EmptyEndpoint: Endpoint {
     
     typealias Content = Data
-    typealias ErrorType = Error
+    typealias Failure = Error
     
     var validateError: EndpointValidationError? = nil
     
-    func makeRequest() throws -> URLRequest {
-        URLRequest(url: URL(string: "empty")!)
+    func makeRequest() -> Result<URLRequest, Error> {
+        return .success(URLRequest(url: URL(string: "empty")!))
     }
     
-    func content(from response: URLResponse?, with body: Data) throws -> Data {
-        return body
-    }
-    
-    func validate(_ request: URLRequest?, response: HTTPURLResponse, data: Data?) throws {
+    func decode(fromResponse response: URLResponse?, withResult result: Result<Data, Error>) -> Result<Data, Error> {
         if let error = validateError {
-            throw error
+            return .failure(error)
         }
-    }
-    
-    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
-        return error
+        return result
     }
 }
 
 private struct SimpleUploadEndpoint: UploadEndpoint {
    
     typealias Content = Data
-    typealias ErrorType = Error
+    typealias Failure = Error
     
     private let data: Data
     
     init(data: Data) {
         self.data = data
     }
-    
-    func makeRequest() throws -> (URLRequest, UploadEndpointBody) {
+
+    func makeRequest() -> Result<(URLRequest, UploadEndpointBody), Error> {
         var req = URLRequest(url: URL(string: "upload")!)
         req.httpMethod = "POST"
         
         let body = UploadEndpointBody.data(data)
-        return (req, body)
+        return .success((req, body))
     }
     
-    func content(from response: URLResponse?, with body: Data) throws -> Data {
-        body
-    }
-    
-    func error(fromResponse response: URLResponse?, withBody body: Data?, withError error: Error) -> Error {
-        return error
+    func decode(fromResponse response: URLResponse?, withResult result: Result<Data, Error>) -> Result<Data, Error> {
+        return result
     }
 }
 

--- a/Tests/ApexyURLSessionTests/URLSessionClientTests.swift
+++ b/Tests/ApexyURLSessionTests/URLSessionClientTests.swift
@@ -149,6 +149,7 @@ private final class MockURLProtocol: URLProtocol {
 private struct EmptyEndpoint: Endpoint {
     
     typealias Content = Data
+    typealias ErrorType = Error
     
     var validateError: EndpointValidationError? = nil
     
@@ -165,11 +166,16 @@ private struct EmptyEndpoint: Endpoint {
             throw error
         }
     }
+    
+    func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+        return error
+    }
 }
 
 private struct SimpleUploadEndpoint: UploadEndpoint {
    
     typealias Content = Data
+    typealias ErrorType = Error
     
     private let data: Data
     
@@ -187,6 +193,10 @@ private struct SimpleUploadEndpoint: UploadEndpoint {
     
     func content(from response: URLResponse?, with body: Data) throws -> Data {
         body
+    }
+    
+    func error(from response: URLResponse?, with body: Data?, and error: Error) -> Error {
+        return error
     }
 }
 


### PR DESCRIPTION
Added advanced error decoding. Now it's easier to declare your own `Error`'s and use them straight from request `Result`