### PR TITLE
Add ability to use custom RequestAdapter with URLSessionClient

### DIFF
--- a/Sources/ApexyURLSession/BaseRequestAdapter.swift
+++ b/Sources/ApexyURLSession/BaseRequestAdapter.swift
@@ -1,20 +1,30 @@
 import Foundation
 
-protocol RequestAdapter {
+/// A type that can inspect and optionally adapt a `URLRequest` in some manner if necessary.
+public protocol RequestAdapter {
     func adapt(_ urlRequest: URLRequest) throws -> URLRequest
 }
 
+/// A type that adapt a `URLRequest` by appending base URL.
 open class BaseRequestAdapter: RequestAdapter {
     
+    /// Contains Base `URL`.
+    ///
+    /// Must end with a slash character `https://example.com/api/v1/`
+    ///
+    /// - Warning: declared as open variable for debug purposes only.
     open var baseURL: URL
     
+    /// Creates a `BaseRequestAdapter` instance with specified Base `URL`.
+    ///
+    /// - Parameter baseURL: Base `URL` for adapter.
     public init(baseURL: URL) {
         self.baseURL = baseURL
     }
     
     // MARK: - RequestAdapter
     
-    public func adapt(_ urlRequest: URLRequest) throws -> URLRequest {
+    open func adapt(_ urlRequest: URLRequest) throws -> URLRequest {
         guard let url = urlRequest.url else {
             throw URLError(.badURL)
         }

--- a/Sources/ApexyURLSession/URLSessionClient.swift
+++ b/Sources/ApexyURLSession/URLSessionClient.swift
@@ -23,13 +23,33 @@ open class URLSessionClient: Client {
     ///   - configuration: The configuration used to construct the managed session.
     ///   - completionQueue: The serial operation queue used to dispatch all completion handlers. `.main` by default.
     ///   - responseObserver: The closure to be called after each response.
-    public init(
+    public convenience init(
         baseURL: URL,
         configuration: URLSessionConfiguration = .default,
         completionQueue: DispatchQueue = .main,
         responseObserver: ResponseObserver? = nil) {
         
-        self.requestAdapter = BaseRequestAdapter(baseURL: baseURL)
+        self.init(
+            requestAdapter: BaseRequestAdapter(baseURL: baseURL),
+            configuration: configuration,
+            completionQueue: completionQueue,
+            responseObserver: responseObserver)
+    }
+    
+    /// Creates new 'URLSessionClient' instance.
+    ///
+    /// - Parameters:
+    ///   - requestAdapter: RequestAdapter used to adapt a `URLRequest`.
+    ///   - configuration: The configuration used to construct the managed session.
+    ///   - completionQueue: The serial operation queue used to dispatch all completion handlers. `.main` by default.
+    ///   - responseObserver: The closure to be called after each response.
+    public init(
+        requestAdapter: RequestAdapter,
+        configuration: URLSessionConfiguration = .default,
+        completionQueue: DispatchQueue = .main,
+        responseObserver: ResponseObserver? = nil) {
+        
+        self.requestAdapter = requestAdapter
         self.session = URLSession(configuration: configuration)
         self.completionQueue = completionQueue
         self.responseObserver = responseObserver

--- a/Tests/ApexyAlamofireTests/BaseRequestInterceptorTests.swift
+++ b/Tests/ApexyAlamofireTests/BaseRequestInterceptorTests.swift
@@ -14,11 +14,11 @@ final class BaseRequestInterceptorTests: XCTestCase {
     
     private let url = URL(string: "https://booklibrary.com")!
     
-    var interceptor: RequestInterceptor {
+    private var interceptor: RequestInterceptor {
         BaseRequestInterceptor(baseURL: url)
     }
     
-    func testAdapt() {
+    func testAdaptWhenURLNotContainsTrailingSlash() {
         let request = URLRequest(url: URL(string: "books/10")!)
         
         let expectation = XCTestExpectation(description: "Wait for completion")
@@ -34,7 +34,7 @@ final class BaseRequestInterceptorTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
     
-    func testAdapt_urlPathWithTrailingSlash() {
+    func testAdaptWhenURLContainsTrailingSlash() {
         let request = URLRequest(url: URL(string: "path/")!)
         let exp = expectation(description: "Adapting url request")
         interceptor.adapt(request, for: .default) { result in
@@ -45,18 +45,7 @@ final class BaseRequestInterceptorTests: XCTestCase {
         wait(for: [exp], timeout: 1)
     }
     
-    func testAdapt_urlPathWithoutTrailingSlash() {
-        let request = URLRequest(url: URL(string: "path")!)
-        let exp = expectation(description: "Adapting url request")
-        interceptor.adapt(request, for: .default) { result in
-            let request = try! result.get()
-            XCTAssertEqual(request.url?.absoluteString, "https://booklibrary.com/path")
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1)
-    }
-    
-    func testAdapt_urlPathWithTrailingSlashWithQuery() {
+    func testAdaptWhenURLContainsQueryItems() {
         let url = URL(string: "api/path/")!
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         components.queryItems = [URLQueryItem(name: "param", value: "value")]
@@ -69,5 +58,22 @@ final class BaseRequestInterceptorTests: XCTestCase {
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1)
+    }
+    
+    func testAdaptWhenRequestContainsHeaders() {
+        var request = URLRequest(url: URL(string: "books")!)
+        request.addValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        
+        let expectation = XCTestExpectation(description: "Wait for completion")
+        interceptor.adapt(request, for: .default) { result in
+            switch result {
+            case .success(let req):
+                XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "application/octet-stream")
+            case .failure:
+                XCTFail("Expected result: .success, actual result: .failure")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
     }
 }

--- a/Tests/ApexyURLSessionTests/BaseRequestAdapterTests.swift
+++ b/Tests/ApexyURLSessionTests/BaseRequestAdapterTests.swift
@@ -1,0 +1,48 @@
+@testable import ApexyURLSession
+import XCTest
+
+final class BaseRequestAdapterTests: XCTestCase {
+    
+    private let url = URL(string: "https://booklibrary.com")!
+    
+    private var adapter: RequestAdapter {
+        BaseRequestAdapter(baseURL: url)
+    }
+    
+    func testAdaptWhenURLNotContainsTrailingSlash() throws {
+        let request = URLRequest(url: URL(string: "books/10")!)
+        
+        let adaptedRequest = try adapter.adapt(request)
+        
+        XCTAssertEqual(adaptedRequest.url?.absoluteString, "https://booklibrary.com/books/10")
+    }
+    
+    func testAdaptWhenURLContainsTrailingSlash() throws {
+        let request = URLRequest(url: URL(string: "path/")!)
+        
+        let adaptedRequest = try adapter.adapt(request)
+        
+        XCTAssertEqual(adaptedRequest.url?.absoluteString, "https://booklibrary.com/path/")
+    }
+    
+    func testAdaptWhenURLContainsQueryItems() throws {
+        let url = URL(string: "api/path/")!
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "param", value: "value")]
+        let request = URLRequest(url: components.url!)
+        
+        let adaptedRequest = try adapter.adapt(request)
+        
+        XCTAssertEqual(adaptedRequest.url?.absoluteString, "https://booklibrary.com/api/path/?param=value")
+    }
+    
+    func testAdaptWhenRequestContainsHeaders() throws {
+        var request = URLRequest(url: URL(string: "books")!)
+        request.addValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        
+        let adaptedRequest = try adapter.adapt(request)
+        
+        XCTAssertEqual(adaptedRequest.value(forHTTPHeaderField: "Content-Type"), "application/octet-stream")
+    }
+    
+}


### PR DESCRIPTION
- Changed access control of `RequestAdapter` (of module `URLSessionClient`) to `public` instead of `internal` to allow developers to make their own adapters.
- Added new initializer to `URLSessionClient` to allow specify a custom adapter.

Closes #19