### PR TITLE
Change access modifier of BaseRequestInterceptor methods to open to allow overriding

### DIFF
--- a/Sources/ApexyAlamofire/BaseRequestInterceptor.swift
+++ b/Sources/ApexyAlamofire/BaseRequestInterceptor.swift
@@ -27,7 +27,7 @@ open class BaseRequestInterceptor: Alamofire.RequestInterceptor {
     
     // MARK: - Alamofire.RequestInterceptor
     
-    public func adapt(
+    open func adapt(
         _ urlRequest: URLRequest,
         for session: Session,
         completion: @escaping (Result<URLRequest, Error>) -> Void) {
@@ -43,7 +43,7 @@ open class BaseRequestInterceptor: Alamofire.RequestInterceptor {
         completion(.success(request))
     }
     
-    public func retry(
+    open func retry(
         _ request: Request,
         for session: Session,
         dueTo error: Error,


### PR DESCRIPTION
Some developers wants to override `adapt` method of `BaseRequestInterceptor`. I've changed access modifier from `public` to `open`.