### PR TITLE
Added unwrapping custom validation error form alamofire error

### DIFF
--- a/Example/Example/Sources/Presentation/Base.lproj/Main.storyboard
+++ b/Example/Example/Sources/Presentation/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -19,7 +20,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="bju-fi-iEV">
                                 <rect key="frame" x="30" y="108" width="120" height="106"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Elz-Bv-PGe">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Elz-Bv-PGe">
                                         <rect key="frame" x="0.0" y="0.0" width="120" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="zKc-wo-BRJ"/>
@@ -29,14 +30,14 @@
                                             <action selector="performRequest" destination="BYZ-38-t0r" eventType="touchUpInside" id="VDc-Ci-dFi"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ske-rf-lBs">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ske-rf-lBs">
                                         <rect key="frame" x="0.0" y="38" width="120" height="30"/>
                                         <state key="normal" title="Upload file"/>
                                         <connections>
                                             <action selector="upload" destination="BYZ-38-t0r" eventType="touchUpInside" id="Sqi-Ex-9hT"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iVc-jZ-c5E">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iVc-jZ-c5E">
                                         <rect key="frame" x="0.0" y="76" width="120" height="30"/>
                                         <state key="normal" title="Upload stream"/>
                                         <connections>
@@ -54,7 +55,6 @@
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w6w-f8-q93">
                                         <rect key="frame" x="0.0" y="0.0" width="354" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
@@ -62,13 +62,13 @@
                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bbD-7E-Czw">
                                 <rect key="frame" x="182" y="108" width="80" height="60"/>
                                 <subviews>
-                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Lg1-id-s3r">
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="Lg1-id-s3r">
                                         <rect key="frame" x="0.0" y="0.0" width="80" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="oHy-zW-9Zo"/>
                                         </constraints>
                                     </activityIndicatorView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hhw-cF-bud">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hhw-cF-bud">
                                         <rect key="frame" x="0.0" y="30" width="80" height="30"/>
                                         <state key="normal" title="Cancel"/>
                                         <connections>
@@ -81,7 +81,8 @@
                                 </constraints>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="bju-fi-iEV" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="64" id="Q9s-Qr-842"/>
                             <constraint firstItem="mW9-zX-l9y" firstAttribute="top" secondItem="bju-fi-iEV" secondAttribute="bottom" constant="27" id="SBx-kI-9Sj"/>
@@ -91,7 +92,6 @@
                             <constraint firstItem="mW9-zX-l9y" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="tnP-cB-H4i"/>
                             <constraint firstItem="bbD-7E-Czw" firstAttribute="leading" secondItem="bju-fi-iEV" secondAttribute="trailing" constant="32" id="uPh-nE-Hsi"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>
                         <outlet property="activityView" destination="bbD-7E-Czw" id="WgW-kx-yo9"/>
@@ -103,4 +103,9 @@
             <point key="canvasLocation" x="137.68115942028987" y="117.85714285714285"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Sources/ApexyAlamofire/BaseRequestInterceptor.swift
+++ b/Sources/ApexyAlamofire/BaseRequestInterceptor.swift
@@ -49,7 +49,7 @@ open class BaseRequestInterceptor: Alamofire.RequestInterceptor {
         dueTo error: Error,
         completion: @escaping (RetryResult) -> Void) {
         
-        return completion(.doNotRetryWithError(error))
+        return completion(.doNotRetry)
     }
     
     // MARK: - Private


### PR DESCRIPTION
Fixed #23

If we throw a custom error from the endpoint `validate` method, the client code will receive `AFError.responseValidationFailed()` error. This PR resolves this issue by removing the unneeded container and rethrowing our custom error.