### PR TITLE
Make ContentLoader init public

### DIFF
--- a/Sources/ApexyLoader/ContentLoader.swift
+++ b/Sources/ApexyLoader/ContentLoader.swift
@@ -30,6 +30,8 @@ open class ContentLoader<Content>: ObservableLoader {
             stateHandlers.forEach { $0.notify() }
         }
     }
+    
+    public init() {}
 
     // MARK: - ObservableLoader
     


### PR DESCRIPTION
`ContentLoader` doesn't have `init`. It's init is internal by default. So developers can't inherit `ContentLoader` e.g. in unit tests to make mock `ContentLoader`. 

When I inherit `ContentLoader` I get the following error:
```swift
'SomeLoaderMock' cannot be constructed because it has no accessible initializers
```

In this PR I marked `ContentLoader` init as public.