### PR TITLE
Default async/await implementation

### DIFF
--- a/Sources/Apexy/AsyncAwaitHelper.swift
+++ b/Sources/Apexy/AsyncAwaitHelper.swift
@@ -12,14 +12,14 @@ public enum AsyncAwaitHelper {
     public typealias ContentContinuation<T> = CheckedContinuation<T, Error>
 
     public static func adaptToAsync<T>(dataTaskClosure: (ContentContinuation<T>) -> Progress) async throws -> T {
-            let progressWrapper = ProgressWrapper()
-            return try await withTaskCancellationHandler(handler: {
-                progressWrapper.cancel()
-            }, operation: {
-                try await withCheckedThrowingContinuation { (continuation: ContentContinuation<T>) in
-                    let progress = dataTaskClosure(continuation)
-                    progressWrapper.progress = progress
-                }
-            })
+        let progressWrapper = ProgressWrapper()
+        return try await withTaskCancellationHandler(handler: {
+            progressWrapper.cancel()
+        }, operation: {
+            try await withCheckedThrowingContinuation { (continuation: ContentContinuation<T>) in
+                let progress = dataTaskClosure(continuation)
+                progressWrapper.progress = progress
+            }
+        })
     }
 }

--- a/Sources/Apexy/AsyncAwaitHelper.swift
+++ b/Sources/Apexy/AsyncAwaitHelper.swift
@@ -1,0 +1,25 @@
+//
+//  AsyncAwaitHelper.swift
+//  
+//
+//  Created by Aleksei Tiurnin on 31.01.2022.
+//
+
+import Foundation
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+public enum AsyncAwaitHelper {
+    public typealias ContentContinuation<T> = CheckedContinuation<T, Error>
+
+    public static func adaptToAsync<T>(dataTaskClosure: (ContentContinuation<T>) -> Progress) async throws -> T {
+            let progressWrapper = ProgressWrapper()
+            return try await withTaskCancellationHandler(handler: {
+                progressWrapper.cancel()
+            }, operation: {
+                try await withCheckedThrowingContinuation { (continuation: ContentContinuation<T>) in
+                    let progress = dataTaskClosure(continuation)
+                    progressWrapper.progress = progress
+                }
+            })
+    }
+}

--- a/Sources/Apexy/Client.swift
+++ b/Sources/Apexy/Client.swift
@@ -42,28 +42,14 @@ public protocol Client: AnyObject {
 public extension Client {
     
     func request<T>(_ endpoint: T) async throws -> T.Content where T: Endpoint {
-        return try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
-            return request(endpoint) { result in
-                switch result {
-                case .success(let content):
-                    return continuation.resume(returning: content)
-                case .failure(let error):
-                    return continuation.resume(throwing: error)
-                }
-            }
+        try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
+            request(endpoint, completionHandler: continuation.resume)
         })
     }
     
     func upload<T>(_ endpoint: T) async throws -> T.Content where T: UploadEndpoint {
-        return try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
-            return upload(endpoint) { result in
-                switch result {
-                case .success(let content):
-                    return continuation.resume(returning: content)
-                case .failure(let error):
-                    return continuation.resume(throwing: error)
-                }
-            }
+        try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
+            upload(endpoint, completionHandler: continuation.resume)
         })
     }
 }

--- a/Sources/Apexy/Client.swift
+++ b/Sources/Apexy/Client.swift
@@ -37,3 +37,33 @@ public protocol Client: AnyObject {
     func upload<T>(_ endpoint: T) async throws -> T.Content where T: UploadEndpoint
     
 }
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+public extension Client {
+    
+    func request<T>(_ endpoint: T) async throws -> T.Content where T: Endpoint {
+        return try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
+            return request(endpoint) { result in
+                switch result {
+                case .success(let content):
+                    return continuation.resume(returning: content)
+                case .failure(let error):
+                    return continuation.resume(throwing: error)
+                }
+            }
+        })
+    }
+    
+    func upload<T>(_ endpoint: T) async throws -> T.Content where T: UploadEndpoint {
+        return try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
+            return upload(endpoint) { result in
+                switch result {
+                case .success(let content):
+                    return continuation.resume(returning: content)
+                case .failure(let error):
+                    return continuation.resume(throwing: error)
+                }
+            }
+        })
+    }
+}

--- a/Sources/ApexyAlamofire/AlamofireClient.swift
+++ b/Sources/ApexyAlamofire/AlamofireClient.swift
@@ -179,32 +179,6 @@ open class AlamofireClient: Client {
         progress.cancellationHandler = { [weak request] in request?.cancel() }
         return progress
     }
-    
-    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func request<T>(_ endpoint: T) async throws -> T.Content where T : Endpoint {
-        typealias ContentContinuation = CheckedContinuation<T.Content, Error>
-        let progressWrapper = ProgressWrapper()
-        return try await withTaskCancellationHandler(handler: {
-            progressWrapper.cancel()
-        }, operation: {
-            try await withCheckedThrowingContinuation { (continuation: ContentContinuation) in
-                progressWrapper.progress = request(endpoint) { continuation.resume(with: $0) }
-            }
-        })
-    }
-    
-    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-    public func upload<T>(_ endpoint: T) async throws -> T.Content where T : UploadEndpoint {
-        typealias ContentContinuation = CheckedContinuation<T.Content, Error>
-        let progressWrapper = ProgressWrapper()
-        return try await withTaskCancellationHandler(handler: {
-            progressWrapper.cancel()
-        }, operation: {
-            try await withCheckedThrowingContinuation { (continuation: ContentContinuation) in
-                progressWrapper.progress = upload(endpoint) { continuation.resume(with: $0) }
-            }
-        })
-    }
 
     // MARK: - Private
 

--- a/Sources/ApexyURLSession/URLSession+AsyncAwait13.swift
+++ b/Sources/ApexyURLSession/URLSession+AsyncAwait13.swift
@@ -18,7 +18,7 @@ extension URLSession {
         for request: URLRequest,
         delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
             return try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
-                let task = self.dataTask(with: request) { data, response, error in
+                let task = dataTask(with: request) { data, response, error in
                     guard let data = data, let response = response else {
                         let error = error ?? URLError(.badServerResponse)
                         return continuation.resume(throwing: error)
@@ -35,7 +35,7 @@ extension URLSession {
         fromFile fileURL: URL,
         delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
             return try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
-                let task = self.uploadTask(with: request, fromFile: fileURL) { data, response, error in
+                let task = uploadTask(with: request, fromFile: fileURL) { data, response, error in
                     guard let data = data, let response = response else {
                         let error = error ?? URLError(.badServerResponse)
                         return continuation.resume(throwing: error)
@@ -52,7 +52,7 @@ extension URLSession {
         from bodyData: Data,
         delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
             return try await AsyncAwaitHelper.adaptToAsync(dataTaskClosure: { continuation in
-                let task = self.uploadTask(with: request, from: bodyData) { data, response, error in
+                let task = uploadTask(with: request, from: bodyData) { data, response, error in
                     guard let data = data, let response = response else {
                         let error = error ?? URLError(.badServerResponse)
                         return continuation.resume(throwing: error)


### PR DESCRIPTION
There is no need to do it yourself. Default implementation uses already implemented methods with closures and wrap them into async/await with cancelation.