### PR TITLE
Resolve URL components against base URL

### DIFF
--- a/Apexy.podspec
+++ b/Apexy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Apexy"
-  s.version      = "1.7.2"
+  s.version      = "1.7.3"
   s.summary      = "HTTP transport library"
   s.homepage     = "https://github.com/RedMadRobot/apexy-ios"
   s.license      = { :type => "MIT"}

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - Alamofire (5.4.1)
-  - Apexy (1.4.1):
-    - Apexy/Alamofire (= 1.4.1)
-  - Apexy/Alamofire (1.4.1):
+  - Apexy (1.7.2):
+    - Apexy/Alamofire (= 1.7.2)
+  - Apexy/Alamofire (1.7.2):
     - Alamofire (~> 5.0)
     - Apexy/Core
-  - Apexy/Core (1.4.1)
+  - Apexy/Core (1.7.2)
 
 DEPENDENCIES:
   - Apexy (from `../`)
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: 2291f7d21ca607c491dd17642e5d40fdcda0e65c
-  Apexy: a9bfb8db4277c3b97d9063cbee34a28c87074c20
+  Apexy: 984a2c615adf4b5af3432859d768a7a3dec51907
 
 PODFILE CHECKSUM: f86a90e7590ccb3aa7caeceaf315abe256650c66
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.12.1

--- a/Sources/Apexy/URLRequestBuildable.swift
+++ b/Sources/Apexy/URLRequestBuildable.swift
@@ -28,7 +28,7 @@ public extension URLRequestBuildable {
             return URLRequest(url: url)
         }
         
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
         components?.queryItems = queryItems
         
         guard let queryURL = components?.url else {


### PR DESCRIPTION
I found one interesting case that this PR fixes.
If I don't use `Adapter` for base URL prepend and want to form full URL in the `Endpoint.makeRequest`, `URLRequestBuildable` create URL without base URL. Take a look into example.

```swift
let relativeURL = URL(string: "/user/1")!
var components = URLComponents(url: relativeURL, resolvingAgainstBaseURL: true)
components?.url // /user/1
components = URLComponents(url: relativeURL, resolvingAgainstBaseURL: false)
components?.url // /user/1

let absoluteURL = URL(string: "/user/1", relativeTo: URL(string: "https://google.com"))!
components = URLComponents(url: absoluteURL, resolvingAgainstBaseURL: false)
components?.url // /user/1 – this behaviour is incorrect
components = URLComponents(url: absoluteURL, resolvingAgainstBaseURL: true)
components?.url // https://google.com/user/1
```
