### PR TITLE
Added the ability to explicitly set host trust evaluation when setting pkeys for SSL pinning

### DIFF
--- a/Sources/ApexyAlamofire/AlamofireClient.swift
+++ b/Sources/ApexyAlamofire/AlamofireClient.swift
@@ -43,6 +43,7 @@ open class AlamofireClient: Client, CombineClient {
         configuration: URLSessionConfiguration,
         completionQueue: DispatchQueue = .main,
         publicKeys: [String: [SecKey]] = [:],
+        evaluateAllHostsForTrust: Bool = true,
         responseObserver: ResponseObserver? = nil,
         eventMonitors: [EventMonitor] = []) {
 
@@ -52,7 +53,7 @@ open class AlamofireClient: Client, CombineClient {
             let evaluators = publicKeys.mapValues { keys in
                 return PublicKeysTrustEvaluator(keys: keys, performDefaultValidation: true, validateHost: true)
             }
-            securityManager = ServerTrustManager(evaluators: evaluators)
+            securityManager = ServerTrustManager(allHostsMustBeEvaluated: evaluateAllHostsForTrust, evaluators: evaluators)
         }
 
         self.completionQueue = completionQueue
@@ -79,6 +80,7 @@ open class AlamofireClient: Client, CombineClient {
         configuration: URLSessionConfiguration,
         completionQueue: DispatchQueue = .main,
         publicKeys: [String: [SecKey]] = [:],
+        evaluateAllHostsForTrust: Bool = true,
         responseObserver: ResponseObserver? = nil,
         eventMonitors: [EventMonitor] = []) {
         self.init(
@@ -86,6 +88,7 @@ open class AlamofireClient: Client, CombineClient {
             configuration: configuration,
             completionQueue: completionQueue,
             publicKeys: publicKeys,
+            evaluateAllHostsForTrust: evaluateAllHostsForTrust,
             responseObserver: responseObserver,
             eventMonitors: eventMonitors)
     }


### PR DESCRIPTION
This PR introduces a new parameter `evaluateAllHostsForTrust` to the initializer of `AlamofireClient`. This parameter directly maps to `allHostsMustBeEvaluated` in Alamofire’s `ServerTrustManager`.

Previously, this value was hardcoded to true (as default value in `ServerTrustManager` initializer), which meant every host had to have a trust evaluator configured. This led to errors like: `noRequiredEvaluator(host:)`. Even for hosts that weren’t meant to use SSL pinning. This made it difficult to use the client in more complex networking setups.

The new parameter defaults to true to preserve backward compatibility and is safe to include in a patch release as it does not break existing behavior.

### TODO:

The current implementation of SSL pinning support in this library is fairly rigid. It tightly couples the usage of `ServerTrustManager` with `PublicKeysTrustEvaluator`, making it impossible to inject or configure alternative evaluators (e.g. certificate pinning, custom logic, etc.).

This change improves flexibility slightly, but a larger refactor would be needed to make the SSL pinning integration truly extensible. That’s a broader topic outside the scope of this patch.